### PR TITLE
Removed a deprecated config line

### DIFF
--- a/lib/vnspec/spec/spec_helper.rb
+++ b/lib/vnspec/spec/spec_helper.rb
@@ -15,7 +15,6 @@ RSpec.configure do |c|
   c.include Vnspec::Logger
   c.include Vnspec::Config
 
-  c.treat_symbols_as_metadata_keys_with_true_values = true
   c.run_all_when_everything_filtered = true
   c.filter_run :focus
 


### PR DESCRIPTION
Rspec was giving us this message:

Deprecation Warnings:

RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= is deprecated, it is now set to true as default and setting it to false has no effect.
