### PR TITLE
Fixed a permission issue in the rotate_log method

### DIFF
--- a/lib/vnspec/vnet.rb
+++ b/lib/vnspec/vnet.rb
@@ -192,9 +192,11 @@ module Vnspec
           logfile = logfile_for(node_name)
           timestamp = "#{Time.now.strftime("%Y%m%d%H%M%S%L")}"
           rotated_logfile = "#{logfile}.#{timestamp}"
-          ssh(ip, "test -f #{logfile} && mv #{logfile} #{rotated_logfile}", use_sudo: true)
-          ssh(ip, "test -f #{rotated_logfile} && gzip #{rotated_logfile}", use_sudo: true)
-          ssh(ip, "touch #{logfile}", use_sudo: true)
+
+          ssh(ip, "cp #{logfile} #{rotated_logfile}", use_sudo: true)
+          ssh(ip, "gzip #{rotated_logfile}", use_sudo: true)
+
+          ssh(ip, "truncate --size 0 #{logfile}", use_sudo: true)
         end
       end
 


### PR DESCRIPTION
### Problem

The log files for vnmgr and webapi belong ot the users `vnet-vnmgr` and `vnet-webapi` respectively. The integration test has a script that empties the logs inbetween tests, but it also set user `root` as the owner of the log files. Vnmgr and webapi would then crash as they don't have sufficient rights to their log files.

### Solution

Instead of moving and recreating the log file, I am copying and emptying it. That way it's owner and permission don't change. I also removed a couple of unnecessary checks from the script.